### PR TITLE
Improves OncoAnalyser path handling and cleans inputs

### DIFF
--- a/app/lambdas/generate_wru_event_object_with_merged_data_py/generate_wru_event_object_with_merged_data.py
+++ b/app/lambdas/generate_wru_event_object_with_merged_data_py/generate_wru_event_object_with_merged_data.py
@@ -88,6 +88,12 @@ def handler(event, context):
     ):
         payload['data']['inputs']['tumorRnaInputs'] = oncoanalyser_wgts_tumor_rna_inputs
 
+    # Remove nulls from inputs
+    payload['data']['inputs'] = dict(filter(
+        lambda kv_iter_: kv_iter_[1] is not None,
+        payload['data']['inputs'].items()
+    ))
+
     # Merge the data from the dragen draft payload into the oncoanalyser draft payload
     new_data_object = payload['data'].copy()
     if new_data_object.get("inputs", None) is None:

--- a/app/lambdas/get_oncoanalyser_wgts_outputs_from_portal_run_id_py/get_oncoanalyser_wgts_outputs_from_portal_run_id.py
+++ b/app/lambdas/get_oncoanalyser_wgts_outputs_from_portal_run_id_py/get_oncoanalyser_wgts_outputs_from_portal_run_id.py
@@ -59,7 +59,7 @@ TUMOR_DNA: TumorDnaInputs = {
     "bamRedux": f"{{DNA_MIDFIX}}/alignments/dna/{{TUMOR_DNA_LIBRARY_ID}}.redux.bam",
     "reduxJitterTsv": f"{{DNA_MIDFIX}}/alignments/dna/{{TUMOR_DNA_LIBRARY_ID}}.jitter_params.tsv",
     "reduxMsTsv": f"{{DNA_MIDFIX}}/alignments/dna/{{TUMOR_DNA_LIBRARY_ID}}.ms_table.tsv.gz",
-    "bamtoolsDir": f"{{DNA_MIDFIX}}/bamtools/{{TUMOR_DNA_LIBRARY_ID}}_bamtools/",
+    "bamtoolsDir": f"{{DNA_MIDFIX}}/bamtools/{{TUMOR_DNA_LIBRARY_ID}}/",
     "sageDir": f"{{DNA_MIDFIX}}/sage_calling/somatic/",
     "linxAnnoDir": f"{{DNA_MIDFIX}}/linx/somatic_annotations/",
     "linxPlotDir": f"{{DNA_MIDFIX}}/linx/somatic_plots/",
@@ -73,7 +73,7 @@ NORMAL_DNA: NormalDnaInputs = {
     "bamRedux": f"{{DNA_MIDFIX}}/alignments/dna/{{NORMAL_DNA_LIBRARY_ID}}.redux.bam",
     "reduxJitterTsv": f"{{DNA_MIDFIX}}/alignments/dna/{{NORMAL_DNA_LIBRARY_ID}}.jitter_params.tsv",
     "reduxMsTsv": f"{{DNA_MIDFIX}}/alignments/dna/{{NORMAL_DNA_LIBRARY_ID}}.ms_table.tsv.gz",
-    "bamtoolsDir": f"{{DNA_MIDFIX}}/bamtools/{{NORMAL_DNA_LIBRARY_ID}}_bamtools/",
+    "bamtoolsDir": f"{{DNA_MIDFIX}}/bamtools/{{NORMAL_DNA_LIBRARY_ID}}/",
     "sageDir": f"{{DNA_MIDFIX}}/sage_calling/germline/",
     "linxAnnoDir": f"{{DNA_MIDFIX}}/linx/germline_annotations/",
 }

--- a/app/lambdas/get_oncoanalyser_wgts_outputs_from_portal_run_id_py/get_oncoanalyser_wgts_outputs_from_portal_run_id.py
+++ b/app/lambdas/get_oncoanalyser_wgts_outputs_from_portal_run_id_py/get_oncoanalyser_wgts_outputs_from_portal_run_id.py
@@ -60,7 +60,7 @@ TUMOR_DNA: TumorDnaInputs = {
     "reduxJitterTsv": f"{{DNA_MIDFIX}}/alignments/dna/{{TUMOR_DNA_LIBRARY_ID}}.jitter_params.tsv",
     "reduxMsTsv": f"{{DNA_MIDFIX}}/alignments/dna/{{TUMOR_DNA_LIBRARY_ID}}.ms_table.tsv.gz",
     "bamtoolsDir": f"{{DNA_MIDFIX}}/bamtools/{{TUMOR_DNA_LIBRARY_ID}}/",
-    "sageDir": f"{{DNA_MIDFIX}}/sage_calling/somatic/",
+    "sageDir": f"{{DNA_MIDFIX}}/sage/somatic/",
     "linxAnnoDir": f"{{DNA_MIDFIX}}/linx/somatic_annotations/",
     "linxPlotDir": f"{{DNA_MIDFIX}}/linx/somatic_plots/",
     "purpleDir": f"{{DNA_MIDFIX}}/purple/",
@@ -74,7 +74,7 @@ NORMAL_DNA: NormalDnaInputs = {
     "reduxJitterTsv": f"{{DNA_MIDFIX}}/alignments/dna/{{NORMAL_DNA_LIBRARY_ID}}.jitter_params.tsv",
     "reduxMsTsv": f"{{DNA_MIDFIX}}/alignments/dna/{{NORMAL_DNA_LIBRARY_ID}}.ms_table.tsv.gz",
     "bamtoolsDir": f"{{DNA_MIDFIX}}/bamtools/{{NORMAL_DNA_LIBRARY_ID}}/",
-    "sageDir": f"{{DNA_MIDFIX}}/sage_calling/germline/",
+    "sageDir": f"{{DNA_MIDFIX}}/sage/germline/",
     "linxAnnoDir": f"{{DNA_MIDFIX}}/linx/germline_annotations/",
 }
 

--- a/app/lambdas/get_oncoanalyser_wgts_outputs_from_portal_run_id_py/get_oncoanalyser_wgts_outputs_from_portal_run_id.py
+++ b/app/lambdas/get_oncoanalyser_wgts_outputs_from_portal_run_id_py/get_oncoanalyser_wgts_outputs_from_portal_run_id.py
@@ -336,12 +336,16 @@ def handle_templates_by_version(portal_run_id: str) -> Tuple:
     tumor_dna = TUMOR_DNA.copy()
     normal_dna = NORMAL_DNA.copy()
 
-    # Get oncoanalyser version
-    if Version(workflow_run_obj['workflow']['version']) < Version('2.2.0'):
-        tumor_dna['sageDir'] = f"{{DNA_MIDFIX}}/sage/somatic/"
-        normal_dna['sageDir'] = f"{{DNA_MIDFIX}}/sage/germline/"
+    # If oncoanalyser version is between 2.2.0 and 2.3.0
+    # We need to update the sageDir output directory
+    if (
+            Version('2.2.0') <= Version(workflow_run_obj['workflow']['version']) < Version('2.3.0')
+    ):
+        tumor_dna['sageDir'] = f"{{DNA_MIDFIX}}/sage_calling/somatic/"
+        normal_dna['sageDir'] = f"{{DNA_MIDFIX}}/sage_calling/germline/"
 
     # Bamtools directory updated in version 2.3.0
+    # Sage calling also temporarily changed in 2.2.0
     if Version(workflow_run_obj['workflow']['version']) < Version('2.3.0'):
         tumor_dna['bamtoolsDir'] = f"{{DNA_MIDFIX}}/bamtools/{{DNA_MIDFIX}}_{{TUMOR_DNA_LIBRARY_ID}}_bamtools/"
         normal_dna['bamtoolsDir'] = f"{{DNA_MIDFIX}}/bamtools/{{DNA_MIDFIX}}_{{NORMAL_DNA_LIBRARY_ID}}_bamtools/"


### PR DESCRIPTION
Enhances OncoAnalyser compatibility for various workflow versions and refines the generation of WRU event objects.

- Updates default `bamtoolsDir` and `sageDir` paths in OncoAnalyser WGTS output templates to align with newer workflow structures.
- Introduces version-specific overrides for `sageDir` paths for OncoAnalyser `v2.2.x` to correctly use `sage_calling` directories, addressing a compatibility issue.
- Adjusts `bamtoolsDir` path generation for OncoAnalyser workflows older than `v2.3.0` to maintain compatibility with previous directory structures.
- Filters out null values from the `inputs` section of the WRU event object payload, ensuring cleaner input data for subsequent processing.